### PR TITLE
utils: create_eos_file_indexes and H5 files

### DIFF
--- a/utils/create_eos_file_indexes.py
+++ b/utils/create_eos_file_indexes.py
@@ -29,6 +29,10 @@ def get_dataset_files(directory, extension=''):
             if match:
                 path, size, checksum = match.groups()
                 if extension and path.endswith(extension):
+                    if extension == 'h5':
+                        # prefer to expose HTTP instead of XRootD
+                        path = path.replace('root://eospublic.cern.ch//eos/opendata/',
+                                            'http://opendata.cern.ch/eos/opendata/')
                     files.append({'filename': os.path.basename(path),
                                   'size': int(size),
                                   'checksum': 'adler32:' + checksum,


### PR DESCRIPTION
* Datasets in H5 format should use HTTP rather then XRootD protocol.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>