### PR TITLE
utils: generate DOIs

### DIFF
--- a/utils/README.rst
+++ b/utils/README.rst
@@ -6,6 +6,7 @@ This directory contains generally useful utilities independent of any specific d
 
 - `aiadm-move-files.sh <aiadm-move-files.sh>`_ - move files from EOS staging area to EOS production area
 - `create_eos_file_indexes.py <create_eos_file_indexes.py>`_ - create EOS file indexes for individual files
+- `generate_dois.py <generate_dois.py>`_ - generate DOIs for record fixtures
 - `merge_delete_fixtures.py <merge_delete_fixtures.py>`_ - helper script to merge record fields
 - `update_fixtures.py <update_fixtures.py>`_ - update some fields in JSON files based on other JSON files
 - `update_checksums.py <update_checksums.py>`_ - update fixture file sizes and checksums based on EOS information

--- a/utils/generate_dois.py
+++ b/utils/generate_dois.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python2
+
+"""Verify whether records need DOI generation.
+
+If a dataset record contains 'files' and does not have 'doi' yet, generate one.
+
+Print record fixtures updated with the generated DOI.
+
+Note: to be run on datasets, software examples, and the like.  Not on
+configuration files and the like.
+
+Note: to be run inside the container after setting
+APP_PIDSTORE_DATACITE_DOI_PREFIX=10.7483 properly in
+fully loaded COD instance.
+"""
+
+import json
+import subprocess
+
+import click
+
+
+def generate_doi(experiment=''):
+    """Return generated DOI for given experiment."""
+    cmd = 'cernopendata datacite gen-doi'
+    if experiment:
+        cmd += ' --exp {0}'.format(experiment)
+    return subprocess.check_output(cmd, shell=True).decode().rstrip('\r\n')
+
+
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+@click.argument('experiment', default='')
+def generate_dois_if_needed(filename, experiment):
+    """Verify whether records need DOI generation.
+
+    If a dataset record contains 'files' and does not have 'doi' yet,
+    generate one.  If 'experiment' is provided, use that for prefix.
+
+    Print record fixtures updated with the generated DOI.
+
+    Note: to be run on datasets, software examples, and the like.  Not on
+    configuration files and the like.
+    """
+    with open(filename, 'r') as fdesc:
+        records = json.loads(fdesc.read())
+
+    changes_needed = False
+    new_dois = []
+    for record in records:
+        # get information
+        recid = record.get('recid')
+        doi = record.get('doi')
+        files = record.get('files', None)
+        # check record
+        if files and not doi:
+            changes_needed = True
+            print("[INFO] Record %s has 'files' but no 'doi'."
+                  " Minting one." % recid)
+
+            while True:
+                new_doi = generate_doi(experiment)
+                if new_doi not in new_dois:
+                    new_dois.append(new_doi)
+                    record['doi'] = new_doi
+                    break
+
+    if changes_needed:
+        new_content = json.dumps(records, indent=2, sort_keys=True,
+                                 ensure_ascii=True, separators=(',', ': '))
+        with open(filename, 'w') as fdesc:
+            fdesc.write(new_content + '\n')
+
+
+if __name__ == '__main__':
+    generate_dois_if_needed()


### PR DESCRIPTION
* Helper script for generating DOIs for record fixtures.

* Note: to be run inside the container after setting
  APP_PIDSTORE_DATACITE_DOI_PREFIX=10.7483 properly in
  fully loaded COD instance.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>