### PR TITLE
cms-release-info: update Dockerfile to non-root

### DIFF
--- a/cms-release-info/Dockerfile
+++ b/cms-release-info/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:alpine
+FROM registry.access.redhat.com/ubi8/nodejs-14
 
+USER 0
+RUN mkdir -p /usr/src/app && \
+    chown -R 1001:0 /usr/src/app
+
+USER 1001
 WORKDIR /usr/src/app
-
-COPY package* ./
-
+ADD package* ./
 RUN npm ci
-
-COPY . .
-
+ADD . .
 CMD ["npm", "start"]


### PR DESCRIPTION
Updates the Dockerfile.
This is running on http://api-server-cms-release-info.app.cern.ch/