### PR TITLE
cms-201Y-collision-datasets-hi: add dataset descriptions

### DIFF
--- a/cms-2013-collision-datasets-hi/inputs/CMSDatasetDescription_Run2013_hi.csv
+++ b/cms-2013-collision-datasets-hi/inputs/CMSDatasetDescription_Run2013_hi.csv
@@ -1,0 +1,19 @@
+/PAHighPt/HIRun2013-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt object or high track multiplicity.
+/PAMinBias1/HIRun2013-PromptReco-v1/RECO:Events stored in this primary dataset are a sample of all events. They are directed in two primary datasets for data processing purposes.
+/PAMinBias2/HIRun2013-PromptReco-v1/RECO:Events stored in this primary dataset are a sample of all events. They are directed in two primary datasets for data processing purposes.
+/PAMinBiasUPC/HIRun2013-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of signs of ultra-peripheral collisions or because they pass certain minimum-bias type selections.
+/PAMuon/HIRun2013-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt muon.
+/PAHighPt/HIRun2013-28Sep2013-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt object or high track multiplicity.
+/PAMinBias1/HIRun2013-28Sep2013-v1/RECO:Events stored in this primary dataset are a sample of all events. They are directed in two primary datasets for data processing purposes.
+/PAMinBiasUPC/HIRun2013-28Sep2013-v1/RECO:Events stored in this primary dataset were selected because of the presence of signs of ultra-peripheral collisions or because they pass certain minimum-bias type selections.
+/PAMuon/HIRun2013-28Sep2013-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt muon.
+/PPFSQ/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of indications of Forward and Small-x QCD (FSQ) physics.
+/PPJet/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt jet or high track multiplicity.
+/PPMinBias/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset were selected because they pass certain minimum-bias type selections.
+/PPMuon/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt muon.
+/PPPhoton/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt photon.
+/PPJet/Run2013A-HighPtPP-15Feb2013-v1/RECO:Events stored in this primary dataset were selected because of the presence of one or more high-pt jet or high track multiplicity. It is a skim of /PPJet/Run2013A-PromptReco-v1/RECO.
+/ZeroBias1/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset are an unbiased sample of all events. They are directed in several primary datasets for data processing purposes.
+/ZeroBias2/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset are an unbiased sample of all events. They are directed in several primary datasets for data processing purposes.
+/ZeroBias3/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset are an unbiased sample of all events. They are directed in several primary datasets for data processing purposes.
+/ZeroBias4/Run2013A-PromptReco-v1/RECO:Events stored in this primary dataset are an unbiased sample of all events. They are directed in several primary datasets for data processing purposes.

--- a/cms-2015-collision-datasets-hi-ppref/inputs/CMSDatasetDescription_Run2015E.csv
+++ b/cms-2015-collision-datasets-hi-ppref/inputs/CMSDatasetDescription_Run2015E.csv
@@ -1,0 +1,33 @@
+/DoubleMu/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of two high-pt muons.
+/FullTrack/Run2015E-PromptReco-v1/AOD: Events stored in this primary dataset were selected because FIXME, check HLT.
+/HeavyFlavor/Run2015E-PromptReco-v1/AOD: Events stored in this primary dataset were selected because of the presence of signs for heavy-flavor mesons.
+/HighMultiplicity/Run2015E-PromptReco-v1/AOD: Events stored in this primary dataset were selected because of high track multiplicity.
+/HighPtJet80/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence jet with a pt above 80 GeV. 
+/HighPtLowerJets/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of a jet with a pt above 80 GeV.
+/HighPtLowerPhotons/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of a jet with a pt above 40 or 60 GeV.
+/HighPtPhoton30AndZ/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of one or more high-pt photons and/or a Z boson (FIXME).
+/MinimumBias1/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias10/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias11/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias12/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias13/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias14/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias15/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias16/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias17/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias18/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias19/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias2/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias20/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias3/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias4/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias5/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias6/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias7/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias8/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MinimumBias9/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are a sample of all events. They are directed in several primary datasets for data processing purposes.
+/MuPlusX/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of a muon and another object.
+/SingleMuHighPt/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of a high-pt muon.
+/SingleMuLowPt/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of a muon with a pt above 3 GeV.
+/ZeroBias/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset are an unbiased sample of all events.
+/ppForward/Run2015E-PromptReco-v1/AOD:Events stored in this primary dataset were selected because of the presence of signs of ultra-peripheral collisions or objects in forward regions.


### PR DESCRIPTION
(addresses #165)

Adds the short dataset descriptions.

There are two with FIXMEs that I need to check from the data-taking config files once the data-taking config page is updated to include HI data-taking
- 2015: https://opendata-qa.web.cern.ch/record/23900, see https://github.com/cernopendata/opendata.cern.ch/issues/3376 
- 2013: the data-taking config links point currently to non-existing https://opendata-qa.web.cern.ch/record/19, see https://github.com/cernopendata/data-curation/pull/159