### PR TITLE
utils: add helper script for adding container_images json field to existing datasets

### DIFF
--- a/cms-release-info/cms_release_container_images_info.json
+++ b/cms-release-info/cms_release_container_images_info.json
@@ -1,7 +1,7 @@
 {
     "CMSSW_7_6_7": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493:latest"
         },
         {
@@ -11,7 +11,7 @@
     ],
     "CMSSW_5_3_32": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_5_3_32-slc6_amd64_gcc472:latest"
         },
         {
@@ -21,7 +21,7 @@
     ],
     "CMSSW_4_4_7": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_4_4_7-slc5_amd64_gcc434:latest"
         },
         {
@@ -31,7 +31,7 @@
     ],
     "CMSSW_4_2_8": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_4_2_8-slc5_amd64_gcc434:latest"
         },
         {
@@ -41,7 +41,7 @@
     ],
     "CMSSW_4_2_8_lowpupatch1": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434:latest"
         },
         {
@@ -51,7 +51,7 @@
     ],
     "CMSSW_3_9_2_patch5": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434:latest"
         },
         {
@@ -61,7 +61,7 @@
     ],
     "CMSSW_10_6_30": [
         {
-            "registry": "docker",
+            "registry": "dockerhub",
             "name": "docker.io/cmsopendata/cmssw_10_6_30-slc7_amd64_gcc700:latest"
         },
         {

--- a/cms-release-info/cms_release_container_images_info.json
+++ b/cms-release-info/cms_release_container_images_info.json
@@ -2,71 +2,71 @@
     "CMSSW_7_6_7": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493"
+            "name": "docker.io/cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_7_6_7-slc6_amd64_gcc493"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_7_6_7-slc6_amd64_gcc493:latest"
         }
     ],
     "CMSSW_5_3_32": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_5_3_32-slc6_amd64_gcc472"
+            "name": "docker.io/cmsopendata/cmssw_5_3_32-slc6_amd64_gcc472:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_5_3_32-slc6_amd64_gcc472"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_5_3_32-slc6_amd64_gcc472:latest"
         }
     ],
     "CMSSW_4_4_7": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_4_4_7-slc5_amd64_gcc434"
+            "name": "docker.io/cmsopendata/cmssw_4_4_7-slc5_amd64_gcc434:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_4_7-slc5_amd64_gcc434"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_4_7-slc5_amd64_gcc434:latest"
         }
     ],
     "CMSSW_4_2_8": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_4_2_8-slc5_amd64_gcc434"
+            "name": "docker.io/cmsopendata/cmssw_4_2_8-slc5_amd64_gcc434:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8-slc5_amd64_gcc434"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8-slc5_amd64_gcc434:latest"
         }
     ],
     "CMSSW_4_2_8_lowpupatch1": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434"
+            "name": "docker.io/cmsopendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434:latest"
         }
     ],
     "CMSSW_3_9_2_patch5": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434"
+            "name": "docker.io/cmsopendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434:latest"
         }
     ],
     "CMSSW_10_6_30": [
         {
             "registry": "docker",
-            "name": "cmsopendata/cmssw_10_6_30-slc7_amd64_gcc700:latest"
+            "name": "docker.io/cmsopendata/cmssw_10_6_30-slc7_amd64_gcc700:latest"
         },
         {
             "registry": "gitlab",
-            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_10_6_30-slc7_amd64_gcc700"
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_10_6_30-slc7_amd64_gcc700:latest"
         }
     ]
 }

--- a/cms-release-info/cms_release_container_images_info.json
+++ b/cms-release-info/cms_release_container_images_info.json
@@ -1,0 +1,72 @@
+{
+    "CMSSW_7_6_7": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_7_6_7-slc6_amd64_gcc493"
+        }
+    ],
+    "CMSSW_5_3_32": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_5_3_32-slc6_amd64_gcc472"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_5_3_32-slc6_amd64_gcc472"
+        }
+    ],
+    "CMSSW_4_4_7": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_4_4_7-slc5_amd64_gcc434"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_4_7-slc5_amd64_gcc434"
+        }
+    ],
+    "CMSSW_4_2_8": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_4_2_8-slc5_amd64_gcc434"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8-slc5_amd64_gcc434"
+        }
+    ],
+    "CMSSW_4_2_8_lowpupatch1": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_4_2_8_lowpupatch1-slc5_amd64_gcc434"
+        }
+    ],
+    "CMSSW_3_9_2_patch5": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_3_9_2_patch5-slc5_amd64_gcc434"
+        }
+    ],
+    "CMSSW_10_6_30": [
+        {
+            "registry": "docker",
+            "name": "cmsopendata/cmssw_10_6_30-slc7_amd64_gcc700:latest"
+        },
+        {
+            "registry": "gitlab",
+            "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_10_6_30-slc7_amd64_gcc700"
+        }
+    ]
+}

--- a/utils/update_fixtures_container_images.py
+++ b/utils/update_fixtures_container_images.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+"""Helper script for updating container_images JSON field of dataset record fixutres.
+
+This helper script is useful for creating/updating the container_images JSON field in
+the CMS datasets found in the CERN Open Data record fixtures. It utilizes the helper script
+update_fixtures.py and cms-release-info/cms_release_container_images_info.json to update
+the datasets.
+
+"""
+
+import os
+import shutil
+import subprocess
+import click
+import json
+
+
+@click.command()
+@click.option(
+    "--input_path", "-i", required=True, help="Relative path to the input directory"
+)
+@click.option(
+    "--output_path", "-o", required=True, help="Relative path to the output directory"
+)
+def main(input_path, output_path):
+    r"""Update datasets to include the container_images JSON field.
+
+    Update datasets found at input_path to include the container_images JSON field
+    and store the updated datasets at output_path.
+
+    Example:
+    \b
+    $ ./utils/update_fixtures_container_images.py -i ../opendata.cern.ch/cernopendata/modules/fixtures/data/records \\
+                                                  -o ../opendata.cern.ch/cernopendata/modules/fixtures/data/records
+    """
+    # find paths to all datasets that need to be updated
+    find_datasets_cmd = f'find {input_path} -type f -name "cms-*-datasets*.json"'
+    target_datasets_paths = subprocess.getoutput(find_datasets_cmd).split("\n")
+
+    # make a temporary directory to hold source records
+    tmp_source_records_dir = "./tmp-source-records"
+    isExist = os.path.exists(tmp_source_records_dir)
+    if not isExist:
+        os.mkdir(tmp_source_records_dir)
+
+    # get container images info
+    with open("./cms-release-info/cms_release_container_images_info.json") as f:
+        container_images_info_json = f.read()
+        container_images_info = json.loads(container_images_info_json)
+
+    # amend target records of all target datasets
+    for target_dataset_path in target_datasets_paths:
+        # read target records
+        target_dataset_basename = os.path.basename(target_dataset_path)[: -len(".json")]
+        target_dataset_content = open(target_dataset_path, "r").read()
+        target_records = json.loads(target_dataset_content)
+
+        # prepare source records
+        source_records = []
+        releases_not_found = set()
+        for record in target_records:
+            source_record = {
+                "title": record["title"],
+                "system_details": record["system_details"],
+            }
+
+            release = record["system_details"]["release"].strip()
+            if release not in container_images_info.keys():
+                releases_not_found.add(release)
+                continue
+            source_record["system_details"]["container_images"] = container_images_info[
+                release
+            ]
+            source_records.append(source_record)
+        if len(releases_not_found) != 0:
+            print(
+                f"{target_dataset_basename}.json: could not find container images info for releases {releases_not_found}"
+            )
+
+        # save source records in a JSON file as required by update_fixtures.py
+        source_records_json = json.dumps(
+            source_records,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ": "),
+        )
+        source_records_path = (
+            f"{tmp_source_records_dir}/{target_dataset_basename}_source.json"
+        )
+        source_records_file = open(source_records_path, "w")
+        source_records_file.write(source_records_json + "\n")
+        source_records_file.close()
+
+        # amend taregt records using update_fixtures.py
+        updated_dataset_path = f"{output_path}/{target_dataset_basename}.json"
+        update_dataset_cmd = f"python3 ./utils/update_fixtures.py -s {source_records_path} -t {target_dataset_path} -m title -u system_details  > {updated_dataset_path}"
+        p = subprocess.run(
+            update_dataset_cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if p.stderr:
+            print(f"Error processing: {target_dataset_basename}.json")
+            print(p.stderr.decode())
+
+    # remove temporary directory
+    shutil.rmtree(tmp_source_records_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- utils: added a helper script that can be used to amend existing datasets to include the new container_images field
- cms-release-info: added a JSON file that stores all CMS releases and their corresponding container images information.