### PR TITLE
cms-201Y-collision-datasets: fix trigger information table header

### DIFF
--- a/cms-2013-hlt-triggers/code/create_hlt_trigger_information_record.py
+++ b/cms-2013-hlt-triggers/code/create_hlt_trigger_information_record.py
@@ -24,7 +24,7 @@ def main():
 
     rec["abstract"] = {}
 
-    abstract_description = '\n      The list of trigger configuration files for the CMS 2013 proton-lead collision data (HIRun2013 from run number 2610498 to run number 211631) and CMS 2013 proton-proton heavy-ion reference collision data (Run2013A from run number 211739 to run number 211831):\n      <table class="table">\n      <thead>'
+    abstract_description = '\n      The list of trigger configuration files for the CMS 2013 proton-lead collision data (HIRun2013 from run number 2610498 to run number 211631) and CMS 2013 proton-proton heavy-ion reference collision data (Run2013A from run number 211739 to run number 211831):\n      <table class="table">\n      <thead>\n     <tr><th>Run number</th><th>Software version</th><th>Trigger configuration</th></tr>\n      </thead>\n      <tbody>'
 
     with open("outputs/cms-trigger-information-2013-helper.html", "r") as fdesc:
 

--- a/cms-2015-collision-datasets/code/create_hlt_trigger_information_record.py
+++ b/cms-2015-collision-datasets/code/create_hlt_trigger_information_record.py
@@ -22,8 +22,7 @@ def main():
 
     rec["abstract"] = {}
 
-    abstract_description = "\n      The list of trigger configuration files for the CMS 2015 proton-proton collision data (Run2015D from run number 256630 to run number 260627, Run2015G from run number 261445 to run number 262328):\n      <table class=\"table\">\n      <thead>"
-
+    abstract_description = "\n      The list of trigger configuration files for the CMS 2015 proton-proton collision data (Run2015D from run number 256630 to run number 260627, Run2015G from run number 261445 to run number 262328):\n      <table class=\"table\">\n      <thead>\n     <tr><th>Run number</th><th>Software version</th><th>Trigger configuration</th></tr>\n      </thead>\n      <tbody>"
     with open("inputs/cms-trigger-information-run2-helper.html", "r") as fdesc:
 
         for line in fdesc.readlines():

--- a/cms-2016-collision-datasets/code/create_hlt_trigger_information_record.py
+++ b/cms-2016-collision-datasets/code/create_hlt_trigger_information_record.py
@@ -37,7 +37,7 @@ def main():
 
     rec["abstract"] = {}
 
-    abstract_description = f"\n      The list of trigger configuration files for the CMS {YEAR_CREATED} proton-proton collision data ({RUN_PERIOD[0]} from run numbers {get_run_range(RUN_PERIOD[0])[0]} and {get_run_range(RUN_PERIOD[0])[1]} & {RUN_PERIOD[1]} from run number {get_run_range(RUN_PERIOD[1])[0]} and {get_run_range(RUN_PERIOD[1])[1]}):\n      <table class=\"ui table striped\">\n      <thead>"
+    abstract_description = f"\n      The list of trigger configuration files for the CMS {YEAR_CREATED} proton-proton collision data ({RUN_PERIOD[0]} from run numbers {get_run_range(RUN_PERIOD[0])[0]} and {get_run_range(RUN_PERIOD[0])[1]} & {RUN_PERIOD[1]} from run number {get_run_range(RUN_PERIOD[1])[0]} and {get_run_range(RUN_PERIOD[1])[1]}):\n      <table class=\"ui table striped\">\n      <thead>\n     <tr><th>Run number</th><th>Software version</th><th>Trigger configuration</th></tr>\n      </thead>\n      <tbody>"
 
 
     with open("inputs/cms-trigger-information-run2-helper.html", "r") as fdesc:


### PR DESCRIPTION
Adds table header generation to the script creating trigger information records.

See cernopendata/opendata.cern.ch#3524