### PR TITLE
cms-2016-collision-datasets: fix RECO checksum generation

### DIFF
--- a/cms-2016-collision-datasets/code/create_reco_config_file_records.py
+++ b/cms-2016-collision-datasets/code/create_reco_config_file_records.py
@@ -5,11 +5,11 @@
 Create RECO CMS Configuration Files records.
 """
 
-import hashlib
 import json
 import re
 import os
 import shutil
+import zlib
 
 
 NOTE = (
@@ -107,9 +107,9 @@ def get_size(afile):
 
 
 def get_checksum(afile):
-    """Return the SHA1 checksum of the configuration file."""
+    """Return the ADLER32 checksum of a file."""
     file_path = "./inputs/config-store/" + afile
-    return hashlib.sha1(open(file_path, "rb").read()).hexdigest()
+    return hex(zlib.adler32(open(file_path, "rb").read(), 1) & 0xFFFFFFFF)[2:]
 
 
 def main():


### PR DESCRIPTION
Changes the checksum generation for RECO configuration to Adler32 that is being used on EOSPUBLIC.